### PR TITLE
bugfix for create_container failures

### DIFF
--- a/cloudfiles_http.php
+++ b/cloudfiles_http.php
@@ -353,11 +353,11 @@ class CF_Http
         $return_code = $this->_send_request("PUT_CONT", $url_path, $hdrs);
         if ($return_code == 401) {
             $this->error_str = "Unauthorized";
-            return array($return_code,$this->response_reason,False);
+            return array($return_code,$this->response_reason,False,False);
         }
         if (!in_array($return_code, array(201,202))) {
             $this->error_str="Unexpected HTTP response: ".$this->response_reason;
-            return array($return_code,$this->response_reason,False);
+            return array($return_code,$this->response_reason,False,False);
         }
         return array($return_code,$this->response_reason,$this->_cdn_uri,
                      $this->_cdn_ssl_uri);


### PR DESCRIPTION
add_cdn_container should return an array of length 4
- method calls to add_cdn_container in CF_Container::make_public will fail with an array of length 3
