### PR TITLE
Changes in create_container() to create public containers

### DIFF
--- a/cloudfiles.php
+++ b/cloudfiles.php
@@ -476,7 +476,7 @@ class CF_Connection
      * @throws SyntaxException invalid name
      * @throws InvalidResponseException unexpected response
      */
-    function create_container($container_name=NULL)
+    function create_container($container_name=NULL,$public=0)
     {
         if ($container_name != "0" and !isset($container_name))
             throw new SyntaxException("Container name not set.");
@@ -495,7 +495,7 @@ class CF_Connection
                 MAX_CONTAINER_NAME_LEN));
         }
 
-        $return_code = $this->cfs_http->create_container($container_name);
+        $return_code = $this->cfs_http->create_container($container_name,$public);
         if (!$return_code) {
             throw new InvalidResponseException("Invalid response ("
                 . $return_code. "): " . $this->cfs_http->get_error());

--- a/cloudfiles_http.php
+++ b/cloudfiles_http.php
@@ -540,7 +540,7 @@ class CF_Http
 
     # PUT /v1/Account/Container
     #
-    function create_container($container_name)
+    function create_container($container_name,$public=0)
     {
         if ($container_name == "")
             throw new SyntaxException("Container name not set.");
@@ -549,7 +549,14 @@ class CF_Http
             throw new SyntaxException("Container name not set.");
 
         $url_path = $this->_make_path("STORAGE", $container_name);
-        $return_code = $this->_send_request("PUT_CONT",$url_path,array("Content-Length"=>"0"));
+
+        // clodo make public support
+        $hdrs = array();
+        $hdrs["Content-Length"] = "0";
+        if ($public)
+            $hdrs["X-Container-Read"] = ".r:*";
+
+        $return_code = $this->_send_request("PUT_CONT",$url_path,$hdrs);
 
         if (!$return_code) {
             $this->error_str .= ": Failed to obtain valid HTTP response.";


### PR DESCRIPTION
**create_container()** - Given a Container name, return a Container instance, creating a new remote Container if it does not exit.

`CF_Container create_container ( string $container_name [, bool $public = false ] )`

_Example:_
`$conn = new CF_Authentication($auth);`
`$images = $conn->create_container("my photos", true);`
